### PR TITLE
2 create user endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
+gem 'active_model_serializers', '~> 0.10.0'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.1)
+    active_model_serializers (0.10.2)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      jsonapi (~> 0.1.1.beta2)
+      railties (>= 4.1, < 6)
     activejob (4.2.1)
       activesupport (= 4.2.1)
       globalid (>= 0.3.0)
@@ -65,6 +70,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jsonapi (0.1.1.beta2)
+      json (~> 1.8)
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -161,6 +168,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   byebug
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,10 +1,21 @@
 class Api::V1::UsersController < ApplicationController
   def create
-    render json: User.create(user_params)
+    user = User.new(user_params)
+    if user.save
+      render status: 201, json: user
+    else
+      render_error(user)
+    end
   end
 
   private
   def user_params
     params.require(:user).permit(:first_name, :last_name, :email, :social_security_number)
+  end
+
+  def render_error(user)
+    render status: 400, json: {
+      message: user.errors.full_messages.join(". ")
+    }
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,10 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    render json: User.create(user_params)
+  end
+
+  private
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, :email, :social_security_number)
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :first_name, :last_name, :email
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-
+  namespace :api do
+    namespace :v1, defaults: {format: :json} do
+      resources :users, only: [:create]
+    end
+  end
 end

--- a/spec/api/v1/users_controller_spec.rb
+++ b/spec/api/v1/users_controller_spec.rb
@@ -8,13 +8,25 @@ RSpec.describe "api::v1::users_controller" do
                      email:      "steve@apple.com",
                      social_security_number: "123456789" }
       post "/api/v1/users", user: user_params
-      expect(response).to be_success #check that 200 is the appropriate response for create
+      expect(response.status).to be 201
       data = JSON.parse(response.body)
       expect(data.keys).to eq(["id", "first_name", "last_name", "email"])
-      epext(data.id).to             eq 1
+      expect(data["id"]).to             eq 1
       expect(data["first_name"]).to eq user_params[:first_name]
       expect(data["last_name"]).to  eq user_params[:last_name]
       expect(data["email"]).to      eq user_params[:email]
+    end
+  end
+
+  context "with invalid params" do
+    scenario "renders an error message" do
+      bad_params =  {email:      "bad email",
+                     social_security_number: "1234" }
+      error_message = "First name can't be blank. Last name can't be blank. Social security number is the wrong length (should be 9 characters). Email is invalid"
+      post '/api/v1/users', user: bad_params
+      expect(response.status).to eq 400
+      data = JSON.parse(response.body)
+      expect(data["message"]).to eq error_message
     end
   end
 end

--- a/spec/api/v1/users_controller_spec.rb
+++ b/spec/api/v1/users_controller_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "api::v1::users_controller" do
+  context "with valid parameters" do
+    scenario "can create a user object, showing only name, email, and id" do
+      user_params = {first_name: "steve",
+                     last_name:  "jobs",
+                     email:      "steve@apple.com",
+                     social_security_number: "123456789" }
+      post "/api/v1/users", user: user_params
+      expect(response).to be_success #check that 200 is the appropriate response for create
+      data = JSON.parse(response.body)
+      expect(data.keys).to eq(["id", "first_name", "last_name", "email"])
+      epext(data.id).to             eq 1
+      expect(data["first_name"]).to eq user_params[:first_name]
+      expect(data["last_name"]).to  eq user_params[:last_name]
+      expect(data["email"]).to      eq user_params[:email]
+    end
+  end
+end


### PR DESCRIPTION
Add a versioned API endpoint for creating a user. Upon successful create, server responds with a 201 status code and returns the created object, showing only the id, email, first name, and last name. Upon unsuccessful create, server sends a 400 response and error messages. Fully tested. 
